### PR TITLE
Extract home feed to standalone content

### DIFF
--- a/circles.html
+++ b/circles.html
@@ -9,4 +9,4 @@
     <li onclick="loadContent('taylorswift.html')">Taylor Swift</li>
     <li onclick="loadContent('groupstudy.html')">Group Study</li>
 </ul>
-<button onclick="loadContent('home.html')">Back to Home</button>
+<button onclick="loadContent('home-content.html')">Back to Home</button>

--- a/comments1.html
+++ b/comments1.html
@@ -8,4 +8,4 @@
     </div>
     <!-- Add more comments as needed -->
 </div>
-<button onclick="loadContent('home.html')">Back to Home</button>
+<button onclick="loadContent('home-content.html')">Back to Home</button>

--- a/comments2.html
+++ b/comments2.html
@@ -8,4 +8,4 @@
     </div>
     <!-- Add more comments as needed -->
 </div>
-<button onclick="loadContent('home.html')">Back to Home</button>
+<button onclick="loadContent('home-content.html')">Back to Home</button>

--- a/home-content.html
+++ b/home-content.html
@@ -1,0 +1,25 @@
+<h2>Home Feed</h2>
+<div class="feed-item">
+    <img src="profile1.jpg" alt="Profile" class="profile-pic">
+    <div class="post-content">
+        <h3>John Doe</h3>
+        <p>Join us for the Welcome Week festivities! Lots of fun activities and events to help you settle in.</p>
+        <div class="post-actions">
+            <button class="like-btn"><i class="fas fa-thumbs-up"></i> Like</button>
+            <button class="comment-btn" onclick="loadContent('comments1.html')"><i class="fas fa-comment"></i> Comment</button>
+            <button class="share-btn"><i class="fas fa-share"></i> Share</button>
+        </div>
+    </div>
+</div>
+<div class="feed-item">
+    <img src="profile2.jpg" alt="Profile" class="profile-pic">
+    <div class="post-content">
+        <h3>Library</h3>
+        <p>The library is now open 24/7 to accommodate all your study needs.</p>
+        <div class="post-actions">
+            <button class="like-btn"><i class="fas fa-thumbs-up"></i> Like</button>
+            <button class="comment-btn" onclick="loadContent('comments2.html')"><i class="fas fa-comment"></i> Comment</button>
+            <button class="share-btn"><i class="fas fa-share"></i> Share</button>
+        </div>
+    </div>
+</div>

--- a/home.html
+++ b/home.html
@@ -7,15 +7,6 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lobster&display=swap">
-    <script>
-        // Redirect to login if not authenticated
-        window.onload = function() {
-            const token = localStorage.getItem('token');
-            if (!token) {
-                window.location.href = 'index.html';
-            }
-        }
-    </script>
 </head>
 <body>
     <div class="app">
@@ -23,34 +14,10 @@
             <h1>UniCircle</h1>
         </header>
         <main class="app-main" id="app-content">
-            <h2>Home Feed</h2>
-            <div class="feed-item">
-                <img src="profile1.jpg" alt="Profile" class="profile-pic">
-                <div class="post-content">
-                    <h3>John Doe</h3>
-                    <p>Join us for the Welcome Week festivities! Lots of fun activities and events to help you settle in.</p>
-                    <div class="post-actions">
-                        <button class="like-btn"><i class="fas fa-thumbs-up"></i> Like</button>
-                        <button class="comment-btn" onclick="loadContent('comments1.html')"><i class="fas fa-comment"></i> Comment</button>
-                        <button class="share-btn"><i class="fas fa-share"></i> Share</button>
-                    </div>
-                </div>
-            </div>
-            <div class="feed-item">
-                <img src="profile2.jpg" alt="Profile" class="profile-pic">
-                <div class="post-content">
-                    <h3>Library</h3>
-                    <p>The library is now open 24/7 to accommodate all your study needs.</p>
-                    <div class="post-actions">
-                        <button class="like-btn"><i class="fas fa-thumbs-up"></i> Like</button>
-                        <button class="comment-btn" onclick="loadContent('comments2.html')"><i class="fas fa-comment"></i> Comment</button>
-                        <button class="share-btn"><i class="fas fa-share"></i> Share</button>
-                    </div>
-                </div>
-            </div>
+            <!-- Dynamic content loads here -->
         </main>
         <nav class="app-nav">
-            <button onclick="loadContent('home.html')"><i class="fas fa-home"></i></button>
+            <button onclick="loadContent('home-content.html')"><i class="fas fa-home"></i></button>
             <button onclick="loadContent('circles.html')"><i class="fas fa-users"></i></button>
             <button onclick="loadContent('messages.html')"><i class="fas fa-envelope"></i></button>
             <button onclick="loadContent('more.html')"><i class="fas fa-ellipsis-h"></i></button>

--- a/script.js
+++ b/script.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    loadContent('home.html'); // Load the home content by default
+    loadContent('home-content.html'); // Load the home content by default
 });
 
 // Handle registration


### PR DESCRIPTION
## Summary
- remove inline auth redirect in `home.html`
- move home feed markup to new `home-content.html`
- adjust navigation and default loading to use `home-content.html`
- update all links that previously loaded `home.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840684d9b64832d9d7409da979667ce