### PR TITLE
Modernize website design

### DIFF
--- a/home-content.html
+++ b/home-content.html
@@ -1,3 +1,9 @@
+<section class="hero">
+    <div class="hero-content">
+        <h2>Welcome to UniCircle</h2>
+        <p>Your hub for campus life</p>
+    </div>
+</section>
 <h2>Home Feed</h2>
 <div class="feed-item">
     <img src="profile1.jpg" alt="Profile" class="profile-pic">

--- a/script.js
+++ b/script.js
@@ -50,7 +50,7 @@ function toggleDarkMode() {
 // Change color scheme
 function changeColorScheme() {
     const colorScheme = document.getElementById('colorScheme').value;
-    document.body.className = document.body.className.replace(/(default|red|blue|green|purple)-scheme/g, '');
+    document.body.className = document.body.className.replace(/(default|red|blue|green|purple|modern)-scheme/g, '');
     document.body.classList.add(`${colorScheme}-scheme`);
     localStorage.setItem('colorScheme', colorScheme);
 }

--- a/settings.html
+++ b/settings.html
@@ -11,5 +11,6 @@
         <option value="blue">Blue</option>
         <option value="green">Green</option>
         <option value="purple">Purple</option>
+        <option value="modern">Modern</option>
     </select>
 </div>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 :root {
-    --primary-color: #ff6b6b; /* modern coral */
-    --secondary-color: #4e9af1;
-    --bg-gradient: linear-gradient(135deg, #ffffff, #ffe6e6);
+    --primary-color: #3b82f6; /* modern blue */
+    --secondary-color: #10b981; /* teal accent */
+    --bg-gradient: linear-gradient(135deg, #eef2ff, #e0f7fa);
 }
 
 body {
@@ -345,8 +345,8 @@ body.dark-mode .settings-item {
 
 /* Color scheme modifiers */
 .default-scheme {
-    --primary-color: #ff6b6b;
-    --bg-gradient: linear-gradient(135deg, #ffffff, #ffe6e6);
+    --primary-color: #3b82f6;
+    --bg-gradient: linear-gradient(135deg, #eef2ff, #e0f7fa);
 }
 
 .red-scheme {
@@ -367,4 +367,52 @@ body.dark-mode .settings-item {
 .purple-scheme {
     --primary-color: #8e24aa;
     --bg-gradient: linear-gradient(135deg, #f3e5f5, #e1bee7);
+}
+
+/* Modern theme */
+.modern-scheme {
+    --primary-color: #3b82f6;
+    --secondary-color: #10b981;
+    --bg-gradient: linear-gradient(135deg, #eef2ff, #e0f7fa);
+}
+
+/* Hero section */
+.hero {
+    position: relative;
+    background-image: url('https://images.unsplash.com/photo-1523050854058-8df90110c9f1?auto=format&fit=crop&w=1050&q=80');
+    background-size: cover;
+    background-position: center;
+    color: #fff;
+    padding: 80px 20px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+    overflow: hidden;
+}
+
+.hero::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.hero-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    animation: fadeUp 0.8s ease-in-out;
+}
+
+.hero h2 {
+    font-size: 36px;
+    margin: 0 0 10px;
+    font-family: 'Lobster', cursive;
+}
+
+.hero p {
+    font-size: 18px;
+    margin: 0;
 }


### PR DESCRIPTION
## Summary
- update global color scheme to modern blues and teals
- add a hero banner to the home feed
- enable new `modern` color scheme in settings
- support the new scheme in JS theme switching

## Testing
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840a4ebb710832db067ee942ca49bcc